### PR TITLE
fix: 회원관리 페이지 나이 및 가입일시 버그 수정

### DIFF
--- a/src/main/resources/templates/admin/mbr_mgmt.html
+++ b/src/main/resources/templates/admin/mbr_mgmt.html
@@ -6,21 +6,7 @@
   <title>관리자-회원관리</title>
   <!-- DataTables CSS -->
   <link href="https://cdn.datatables.net/2.0.8/css/dataTables.bootstrap5.min.css" rel="stylesheet">
-  <!-- SweetAlert2 -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-
 <body>
-<div th:if="${message}">
-  <script th:inline="javascript">
-    Swal.fire({
-      icon: [[${status}]] === 'success' ? 'success' : 'error',
-      title: [[${status}]] === 'success' ? '성공' : '실패',
-      text: [[${message}]],
-      confirmButtonText: '확인'
-    });
-  </script>
-</div>
 <div class="page">
   <th:block th:replace="~{dailyband/navbar :: navbarFragment}"/>
   <th:block th:replace="~{dailyband/header :: headerFragment}"/>
@@ -49,12 +35,12 @@
                 <h3>회원 정보 조회</h3>
               </div>
               <div class="card-body">
-                  <table id="mbr_table" class="table table-vcenter card-table table-bordered" style="width:100%">
+                  <table id="mbr_table" class="table table-vcenter card-table" style="width:100%">
                     <thead>
-                    <tr>
+                    <tr style="background: #f6f8fb">
                       <th>아이디</th>
                       <th>이메일</th>
-                      <th>밴드 팀명</th>
+                      <th>참여 밴드</th>
                       <th>닉네임</th>
                       <th>성별</th>
                       <th>나이</th>
@@ -66,14 +52,12 @@
                     <tbody>
                     <tr th:each="m : ${memberlist}">
                       <td>
-                        <th:block th:if="${m['MBR_ID'] != username}">
                         <span class="avatar avatar-sm"
                               th:style="|background-image: url('${m['MBR_PROFL_PHOTO']}');| "></span>
+                        <th:block th:if="${m['MBR_ID'] != username}">
                         <a th:href="@{../member/info(id=${m.MBR_ID})}">[[${m['MBR_ID']}]]</a>
                         </th:block>
                         <th:block th:if="${m.MBR_ID == username}">
-                        <span class="avatar avatar-sm"
-                              th:style="|background-image: url('${m.MBR_PROFL_PHOTO}');| "></span>
                           <a th:href="@{../member/myprofile}">[[${m['MBR_ID']}]]</a>
                         </th:block>
                       </td>
@@ -81,8 +65,8 @@
                       <td>[[${m['BAND_NM']}]]</td>
                       <td>[[${m['MBR_NCNM']}]]</td>
                       <td>[[${m['MBR_GENDER']}]]</td>
-                      <td th:if="${m['MBR_AGE'] != 0}">[[${m['MBR_AGE']}]]세</td>
-                      <td th:if="${m['MBR_AGE'] == 0}"></td>
+                      <td th:if="${m['MBR_AGE'] != 0 and m['MBR_AGE'] != null}">[[${m['MBR_AGE']}]]세</td>
+                      <td th:unless="${m['MBR_AGE'] != 0 and m['MBR_AGE'] != null}"></td>
                       <td class="text-end" sec:authorize="hasAnyRole('ROLE_ADMIN')">
                         <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown" th:if="${m.MBR_TY == 'ROLE_MEMBER'}">회원</a>
                         <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown" th:if="${m.MBR_TY == 'ROLE_MANAGER'}">매니저</a>
@@ -106,7 +90,7 @@
                           <a class="dropdown-item" th:href="@{changeStatus(id=${m.MBR_ID}, newStatus=1)}">비활성화</a>
                         </div>
                       </td>
-                      <td>[[${m['REG_DT']}]]</td>
+                      <td th:text="${#strings.substring(m['REG_DT'], 0, 19)}">[[${m['REG_DT']}]]</td>
                     </tr>
                     </tbody>
                   </table>
@@ -122,6 +106,17 @@
 <!-- DataTables JS -->
 <script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
 <script src="https://cdn.datatables.net/2.0.8/js/dataTables.bootstrap5.min.js"></script>
+<div th:if="${message}">
+  <script th:inline="javascript">
+    Swal.fire({
+      icon: [[${status}]] === 'success' ? 'success' : 'error',
+      title: [[${status}]] === 'success' ? '성공' : '실패',
+      text: [[${message}]],
+      confirmButtonText: '확인',
+      heightAuto: false
+    });
+  </script>
+</div>
 <script>
   $('#mbr_table').DataTable({
     responsive: true,


### PR DESCRIPTION
- 나이 if문에 null 조건 추가
- 가입일시 소수단위 초 substring으로 제외

Ref: #7

### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :나이에 null 조건 추가, 가입일시 소수 단위초 제외
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 정보수정을 한번도 안하면 나이는 null이라 조건 추가하였음
- 가입일시가 소수 단위초까지 나와서 substring으로 제외 하였음

### 작업 내역

- 나이에 타임리프 if문 수정
- 가입일시 substring 적용

### 작업 후 기대 동작(스크린샷)

- 회원 정보 조회
![image](https://github.com/hcm01316/DailyBand/assets/76554531/3a4bd0d2-7f1f-4f02-aeac-82fcc69ddfa7)


### PR 특이 사항

- 특이 사항 없음

### Issue Number 

Ref: #7

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
