### PR TITLE
fix: 밴드 일정 페이지제한,버그 수정

### DIFF
--- a/src/main/java/com/bnd/dailyband/controller/BandCalendarController.java
+++ b/src/main/java/com/bnd/dailyband/controller/BandCalendarController.java
@@ -2,15 +2,20 @@ package com.bnd.dailyband.controller;
 
 import com.bnd.dailyband.domain.Calendar;
 import com.bnd.dailyband.domain.Member;
+import com.bnd.dailyband.domain.Rboard;
 import com.bnd.dailyband.service.Calendar.CalendarService;
+import com.bnd.dailyband.service.rboard.RboardService;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.annotation.CurrentSecurityContext;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
 
 import java.util.List;
 
@@ -21,20 +26,45 @@ public class BandCalendarController {
 
     @Autowired
     private CalendarService calendarService;
+
+    public BandCalendarController(CalendarService calendarService, RboardService rboardService){
+        this.calendarService = calendarService;
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(BandCalendarController.class);
 
     @GetMapping("/bandcal")
-    public String showBandCalendarPage(Model model) {
-        model.addAttribute("current", "bandCal");
-        model.addAttribute("bbsSn",20);
-        return "calendar/band_calendar";
+    public ModelAndView showBandCalendarPage(ModelAndView mv, @CurrentSecurityContext SecurityContext userPrincipal) {
+
+        String id = userPrincipal.getAuthentication().getName();
+        mv.addObject("id", id);
+
+        Rboard rboard = calendarService.bandck(id);
+
+        int bandck = 0;
+        if(rboard == null){
+            bandck = -1;
+        }
+        mv.addObject("bandck", bandck);
+
+        if (bandck == -1) {
+            mv.addObject("isband", 0);
+        }
+        if (bandck != -1)
+        {
+            mv.addObject("bbsSn",rboard.getBBS_SN());
+        }
+        mv.addObject("current", "bandCal");
+        mv.setViewName("calendar/band_calendar");
+
+        return mv;
     }
 
     @GetMapping("/select")
     @ResponseBody
-    public List<Calendar> select(){
+    public List<Calendar> select(int bbsSn){
 
-        return calendarService.getAllCalendars(20);
+        return calendarService.getAllCalendars(bbsSn);
 
     }
 

--- a/src/main/java/com/bnd/dailyband/mybatis/mapper/CalendarMapper.java
+++ b/src/main/java/com/bnd/dailyband/mybatis/mapper/CalendarMapper.java
@@ -1,6 +1,7 @@
 package com.bnd.dailyband.mybatis.mapper;
 
 import com.bnd.dailyband.domain.Calendar;
+import com.bnd.dailyband.domain.Rboard;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -11,4 +12,5 @@ public interface CalendarMapper {
     List<Calendar> getAllCalendars(int bbs_sn);
     void deleteCalendar(int cal_id);
     void updateCalendar(Calendar calendar);
+    Rboard bandck (String id);
 }

--- a/src/main/java/com/bnd/dailyband/service/Calendar/CalendarService.java
+++ b/src/main/java/com/bnd/dailyband/service/Calendar/CalendarService.java
@@ -1,6 +1,7 @@
 package com.bnd.dailyband.service.Calendar;
 
 import com.bnd.dailyband.domain.Calendar;
+import com.bnd.dailyband.domain.Rboard;
 
 import java.util.List;
 
@@ -9,4 +10,5 @@ public interface CalendarService {
     List<Calendar> getAllCalendars(int bbs_sn);
     void deleteCalendar(int cal_id);
     void updateCalendar(Calendar calendar);
+    public Rboard bandck(String id);
 }

--- a/src/main/java/com/bnd/dailyband/service/Calendar/CalendarServiceImpl.java
+++ b/src/main/java/com/bnd/dailyband/service/Calendar/CalendarServiceImpl.java
@@ -1,6 +1,7 @@
 package com.bnd.dailyband.service.Calendar;
 
 import com.bnd.dailyband.domain.Calendar;
+import com.bnd.dailyband.domain.Rboard;
 import com.bnd.dailyband.mybatis.mapper.CalendarMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,12 @@ public class CalendarServiceImpl implements CalendarService {
     @Override
     public void updateCalendar(Calendar calendar) {
         calendarMapper.updateCalendar(calendar);
+    }
+
+    @Override
+    public Rboard bandck(String id) {
+        return calendarMapper.bandck(id);
+
     }
 
 }

--- a/src/main/resources/com/bnd/dailyband/mybatis/mapper/CalendarMapper.xml
+++ b/src/main/resources/com/bnd/dailyband/mybatis/mapper/CalendarMapper.xml
@@ -8,8 +8,16 @@
     </insert>
 
     <select id="getAllCalendars" resultType="com.bnd.dailyband.domain.Calendar">
-        SELECT * FROM CALENDAR WHERE bbs_sn = #{bbs_sn}
+        SELECT c.*
+        FROM CALENDAR c
+                 INNER JOIN BAND_PRPT_INFO b ON c.bbs_sn = b.BBS_SN
+        WHERE c.bbs_sn = #{bbs_sn} AND b.MBR_PRPT_STTUS IN (1, 2)
     </select>
+
+    <select id="bandck" resultType="Rboard">
+        select BBS_SN from BAND_PRPT_INFO where MBR_PRPT_STTUS IN (1,2) and MBR_ID = #{id}
+    </select>
+
 
     <delete id="deleteCalendar">
         DELETE FROM CALENDAR WHERE cal_id = #{cal_id}

--- a/src/main/resources/templates/calendar/band_calendar.html
+++ b/src/main/resources/templates/calendar/band_calendar.html
@@ -70,6 +70,38 @@
             </div>
         </div>
         <div class="page-body">
+            <th:block th:if="${isband} == 0">
+                <div class="empty">
+                    <div class="empty-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                             viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                             stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <circle cx="12" cy="12" r="9"/>
+                            <line x1="9" y1="10" x2="9.01" y2="10"/>
+                            <line x1="15" y1="10" x2="15.01" y2="10"/>
+                            <path d="M9.5 15.25a3.5 3.5 0 0 1 5 0"/>
+                        </svg>
+                    </div>
+                    <p class="empty-title">가입한 밴드가 없습니다.</p>
+                    <p class="empty-subtitle text-secondary">
+                        밴드원 모집에서 새로운 밴드를 만들거나 가입하세요.
+                    </p>
+                    <div class="empty-action">
+                        <a th:href="@{/rboard/list}" class="btn btn-primary">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                                 stroke-linecap="round" stroke-linejoin="round">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                                <circle cx="10" cy="10" r="7"/>
+                                <line x1="21" y1="21" x2="15" y2="15"/>
+                            </svg>
+                            밴드가입 및 생성
+                        </a>
+                    </div>
+                </div>
+            </th:block>
+            <th:block th:if="${isband} != 0">
             <div class="container-xl">
                 <div id="yrModal" style="display:none;">
                     <div id="modalContent">
@@ -98,6 +130,7 @@
                     <div id='calendar'></div>
                 </div>
             </div>
+            </th:block>
         </div>
         <th:block th:replace="~{dailyband/footer :: footerFragment}"/>
     </div>
@@ -106,7 +139,7 @@
     let token = $("meta[name='_csrf']").attr("content");
     let header = $("meta[name='_csrf_header']").attr("content");
 
-    const bbsSn = [[${bbsSn}]]
+    const bandck = [[${bandck}]]
 
     let calendar = {}
 
@@ -122,12 +155,15 @@
         const YrModal = document.querySelector("#yrModal");
 
         let respondata = [];
+        const bbsSn = [[${bbsSn}]]
 
         function getlist(){
+
             $.ajax({
                 url:"select",
                 method : "GET",
                 async : false,
+                data : {bbsSn : bbsSn},
                 success : function (rdata){
 
                     respondata = rdata;
@@ -203,6 +239,7 @@
                 }
             })
         }
+        if(bandck != -1)
         getlist();
 
 
@@ -232,6 +269,11 @@
             if (!mySchTitle.value) {
                 alert("제목을 입력하세요.");
                 mySchTitle.focus();
+                return;
+            }
+
+            if (!mySchAllday.checked && (!mySchStartTime.value || !mySchEndTime.value)) {
+                alert("시작시간과 종료시간을 선택하세요.");
                 return;
             }
 


### PR DESCRIPTION
밴드 일정 자기 소속 밴드 일정 캘린더 보여주기
모달창에서 시간미입력 상태에서 추가 누를시 모달창 사라지는 버그 수정

### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 밴드일정 페이지제한,버그 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이유

### 작업 내역

- 밴드 일정 자기 소속 밴드 일정 캘린더 보여주기
모달창에서 시간미입력 상태에서 추가 누를시 모달창 사라지는 버그 수정

### 작업 후 기대 동작(스크린샷)

- 동작 

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
