### PR TITLE
fix: 회원 관리 회원 참여 밴드 버그 수정

### DIFF
--- a/src/main/resources/com/bnd/dailyband/mybatis/mapper/admin.xml
+++ b/src/main/resources/com/bnd/dailyband/mybatis/mapper/admin.xml
@@ -6,12 +6,23 @@
 
   <!-- 회원 목록 -->
   <select id="getMemberList" resultType="map">
-    select m.*, r.BAND_TEAM_NM as BAND_NM
-    from MBR_INFO m
-           left join RCRIT_BBS r
-                     on m.MBR_ID = r.MBR_ID
-    where m.MBR_ID != 'admin'
-    group by m.MBR_ID;
+    SELECT m.*,
+           CASE
+             WHEN bpi.MBR_PRPT_STTUS IN (1, 2) THEN
+               COALESCE(r.BAND_TEAM_NM,
+                        (SELECT rb2.BAND_TEAM_NM
+                         FROM RCRIT_BBS rb2
+                         WHERE rb2.BBS_SN = bpi.BBS_SN
+                           AND rb2.BAND_TEAM_NM IS NOT NULL
+                         LIMIT 1))
+             END AS BAND_NM
+    FROM MBR_INFO m
+           LEFT JOIN
+         BAND_PRPT_INFO bpi ON m.MBR_ID = bpi.MBR_ID
+           LEFT JOIN
+         RCRIT_BBS r ON m.MBR_ID = r.MBR_ID
+    WHERE m.MBR_ID != 'admin'
+    GROUP BY m.MBR_ID, bpi.MBR_PRPT_STTUS;
   </select>
 
   <!-- 회원 권한 변경 -->


### PR DESCRIPTION
회원 관리에서 리더가 아닌 밴드에 참여 중인 회원의 참여 밴드명이 없어 수정

Ref: #7

### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 회원 관리 참여 밴드 버그 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 회원 관리 페이지에서 밴드원 모집 글을 작성한 리더만 참여 밴드가 있고, 그 밴드에 수락되어 참여하고 있는 회원은 참여 밴드 가 없어 sql 수정 하였음

### 작업 내역

- 회원 목록 sql 수정

### 작업 후 기대 동작(스크린샷)

-  회원 관리
![image](https://github.com/hcm01316/DailyBand/assets/76554531/9f4bf568-294b-4502-844e-d8ef775217d3)


### PR 특이 사항

- 특이 사항 없음

### Issue Number 

Ref: #7

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
